### PR TITLE
Bugfix theme upload

### DIFF
--- a/cmd/theme/main.go
+++ b/cmd/theme/main.go
@@ -16,6 +16,7 @@ const commandDefault string = "download [<file> ...]"
 var globalEventLog chan themekit.ThemeEvent
 
 var permittedZeroArgCommands = map[string]bool{
+	"upload":   true,
 	"download": true,
 	"replace":  true,
 	"watch":    true,

--- a/cmd/theme/main.go
+++ b/cmd/theme/main.go
@@ -106,7 +106,9 @@ func main() {
 			if !more {
 				return
 			}
-			fmt.Println(event)
+			if len(event.String()) > 0 {
+				fmt.Println(event)
+			}
 		}
 	}()
 	<-done

--- a/event_filter.go
+++ b/event_filter.go
@@ -15,7 +15,8 @@ import (
 const ConfigurationFilename string = "config\\.yml"
 
 var defaultRegexes []*re.Regexp = []*re.Regexp{
-	re.MustCompile(`\.*`),
+	re.MustCompile(`\.git/*`),
+	re.MustCompile(`\.DS_Store`),
 }
 
 var defaultGlobs []string = []string{}
@@ -108,9 +109,11 @@ func (e EventFilter) MatchesFilter(event string) bool {
 
 func (e EventFilter) String() string {
 	buffer := bytes.NewBufferString(strings.Join(e.globs, "\n"))
+	buffer.WriteString("--- endglobs ---\n")
 	for _, rxp := range e.filters {
 		buffer.WriteString(fmt.Sprintf("%s\n", rxp))
 	}
+	buffer.WriteString("-- done --")
 	return buffer.String()
 }
 

--- a/event_filter_test.go
+++ b/event_filter_test.go
@@ -2,10 +2,11 @@ package themekit
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestEventFilterRejectsEventsThatMatch(t *testing.T) {
@@ -41,6 +42,13 @@ func TestFilterRemovesEmptyStrings(t *testing.T) {
 	eventFilter := NewEventFilterFromReaders([]io.Reader{})
 	inputEvents := []string{"hello", "", "world"}
 	expectedEvents := []string{"hello", "world"}
+	assertFilter(t, eventFilter, inputEvents, expectedEvents)
+}
+
+func TestDefaultFilters(t *testing.T) {
+	eventFilter := NewEventFilterFromReaders([]io.Reader{})
+	inputEvents := []string{".git/HEAD", ".DS_Store", "config.yml", "templates/products.liquid"}
+	expectedEvents := []string{"templates/products.liquid"}
 	assertFilter(t, eventFilter, inputEvents, expectedEvents)
 }
 

--- a/file_watcher.go
+++ b/file_watcher.go
@@ -14,7 +14,7 @@ import (
 
 const EventTimeoutInMs int64 = 3000
 
-var assetLocations = []string{"templates/customers", "assets", "config", "layout", "snippets", "templates"}
+var assetLocations = []string{"templates/customers", "assets", "config", "layout", "snippets", "templates", "locales"}
 
 type FsAssetEvent struct {
 	asset     Asset

--- a/theme_client.go
+++ b/theme_client.go
@@ -163,9 +163,7 @@ func (t ThemeClient) Process(events chan AssetEvent) (done chan bool, messages c
 		for {
 			job, more := <-events
 			if more {
-				if !t.filter.MatchesFilter(job.Asset().Key) {
-					messages <- t.Perform(job)
-				}
+				messages <- t.Perform(job)
 			} else {
 				close(messages)
 				done <- true
@@ -177,6 +175,9 @@ func (t ThemeClient) Process(events chan AssetEvent) (done chan bool, messages c
 }
 
 func (t ThemeClient) Perform(asset AssetEvent) ThemeEvent {
+	if t.filter.MatchesFilter(asset.Asset().Key) {
+		return NoOpEvent{}
+	}
 	var event string
 	switch asset.Type() {
 	case Update:

--- a/theme_client_test.go
+++ b/theme_client_test.go
@@ -39,6 +39,23 @@ func TestPerformWithRemoveAssetEvent(t *testing.T) {
 	client.Perform(asset)
 }
 
+func TestPerformWithAssetEventThatDoesNotPassTheFilter(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Log("The request should never have been sent")
+		t.Fail()
+	}))
+	defer ts.Close()
+	config := conf(ts)
+	config.IgnoredFiles = []string{"snickerdoodle.txt"}
+	config.Ignores = []string{}
+
+	asset := Asset{Key: "snickerdoodle.txt", Value: "not important"}
+	event := TestEvent{asset: asset, eventType: Update}
+
+	client := NewThemeClient(config)
+	client.Perform(event)
+}
+
 func TestProcessingAnEventsChannel(t *testing.T) {
 	results := map[string]int{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/theme_event.go
+++ b/theme_event.go
@@ -21,6 +21,25 @@ type ThemeEvent interface {
 	AsJSON() ([]byte, error)
 }
 
+type NoOpEvent struct {
+}
+
+func (e NoOpEvent) String() string {
+	return ""
+}
+
+func (e NoOpEvent) Successful() bool {
+	return false
+}
+
+func (e NoOpEvent) Error() error {
+	return nil
+}
+
+func (e NoOpEvent) AsJSON() ([]byte, error) {
+	return []byte{}, errors.New("cannot encode NoOpEvents")
+}
+
 type APIAssetEvent struct {
 	Host      string `json:"host"`
 	AssetKey  string `json:"asset_key"`


### PR DESCRIPTION
This fixes upload such that a request to upload will upload all files instead of having to specify the exact files.

- Also fixes a bug with git repositories
- Makes filters work within the theme client so filtering should come for free now