### PR TITLE
Gives theme watch the ability to upload to all environments

### DIFF
--- a/commands/common.go
+++ b/commands/common.go
@@ -77,6 +77,25 @@ func extractThemeClient(t *themekit.ThemeClient, args map[string]interface{}) {
 	}
 }
 
+func extractThemeClients(args map[string]interface{}) []themekit.ThemeClient {
+	if args["environments"] == nil {
+		return []themekit.ThemeClient{}
+	}
+
+	var ok bool
+	var environments themekit.Environments
+	if environments, ok = args["environments"].(themekit.Environments); !ok {
+		themekit.NotifyError(errors.New("environments is not of a valid type"))
+	}
+	clients := make([]themekit.ThemeClient, len(environments), len(environments))
+	idx := 0
+	for _, configuration := range environments {
+		clients[idx] = themekit.NewThemeClient(configuration)
+		idx++
+	}
+	return clients
+}
+
 func extractEventLog(el *chan themekit.ThemeEvent, args map[string]interface{}) {
 	var ok bool
 


### PR DESCRIPTION
This will allow a developer to have various test shops in numerous
configurations and see their changes on all the shops at roughly
the same time.

This feature still needs a bit of work, but it's a good starting point.
- Each shop gets it's own directory watcher, instead we could demux the
  channel and feed the results to each of the Formen.
- The output is interleaved so it's difficult to visually tell which shop
  got what. Colourized output per shop would be handy

------------------------
Screenshots:
![screenshot 2015-06-25 10 16 43](https://cloud.githubusercontent.com/assets/82491/8357423/cbc81bee-1b28-11e5-8736-eefa5d979980.png)
![screenshot 2015-06-25 10 17 00](https://cloud.githubusercontent.com/assets/82491/8357474/0b3fbf02-1b29-11e5-9cb6-3f7583b365e5.png)

------------------------
Usage:
- `theme watch --allenvs`

----------------------
Caveats:
- This uploads to all shops without prejudice, so you might want to be sure your production shop isn't in that configuration. Maybe we'd want to add an additional argument; something like `--except` perhaps?

/cc @stevebosworth @cshold